### PR TITLE
Prevent duplicated webroot prefix in entrypoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
         "test": "phpunit --colors=always"
     },
     "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
         "sort-packages": true
     }
 }

--- a/src/View/Helper/RnaHelper.php
+++ b/src/View/Helper/RnaHelper.php
@@ -97,15 +97,12 @@ class RnaHelper extends Helper
         $request = $view->getRequest();
         $patched = $request->withAttribute('webroot', '/');
         $view->setRequest($patched);
-        $res = null;
 
         try {
-            $res = $callback();
+            return $callback();
         } finally {
             $view->setRequest($request);
         }
-
-        return $res;
     }
 
     /**


### PR DESCRIPTION
Patch current request with an empty webroot attribute.

Since RNA's entrypoints already includes the full webroot path, we are removing the `webroot` attribute in order to prevent additional prefix when using `Html::script` and `Html::css` methods.