### PR TITLE
Fix support for cake 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "cakephp/cakephp": "^4.0"
+        "cakephp/cakephp": "^4.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0 || ^8.5 || ^9.3",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.4",
         "ext-json": "*",
-        "cakephp/cakephp": "~3.9 || ~4.2"
+        "cakephp/cakephp": "^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0 || ^8.5 || ^9.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "cakephp/cakephp": "^4.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0 || ^8.5 || ^9.3",
+        "phpunit/phpunit": "~8.5.0 || ^9.3",
         "cakephp/cakephp-codesniffer": "~4.2.0"
     },
     "autoload": {


### PR DESCRIPTION
Cake 4 does not use View's request to generate urls. Instead, it uses the current Router request, so we need to change the method to patch the correct request instance.